### PR TITLE
[ADD] rendition report

### DIFF
--- a/constans.go
+++ b/constans.go
@@ -30,9 +30,14 @@ const (
 	ExtFrameStreamInf  = `#EXT-X-I-FRAME-STREAM-INF`
 
 	// for low-latency
-	ExtServerControl = `#EXT-X-SERVER-CONTROL`
-	ExtPartInf       = `#EXT-X-PART-INF`
-	ExtPart          = `#EXT-X-PART`
+	ExtServerControl   = `#EXT-X-SERVER-CONTROL`
+	ExtPartInf         = `#EXT-X-PART-INF`
+	ExtPart            = `#EXT-X-PART`
+	ExtRenditionReport = `#EXT-X-RENDITION-REPORT`
+
+	// rendition report
+	LASTMSN  = "LAST-MSN"
+	LASTPART = "LAST-PART"
 
 	// server control
 	CANBLOCKRELOAD = "CAN-BLOCK-RELOAD"

--- a/report.go
+++ b/report.go
@@ -1,15 +1,48 @@
 package m3u8
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
 type RenditionReportSegment struct {
 	URI      string
-	LastMSN  int
-	LastPART int
+	LastMSN  uint64
+	LastPART uint64
 }
 
 func NewReport(line string) (*RenditionReportSegment, error) {
-	return &RenditionReportSegment{}, nil
+	item := parseLine(line[len(ExtRenditionReport+":"):])
+
+	lastMSN, err := extractUint64(item, LASTMSN)
+	if err != nil {
+		return nil, errors.Wrap(err, "extractUint64 err")
+	}
+
+	lastPART, err := extractUint64(item, LASTPART)
+	if err != nil {
+		return nil, errors.Wrap(err, "extractUint64 err")
+	}
+	return &RenditionReportSegment{
+		URI:      item[URI],
+		LastMSN:  lastMSN,
+		LastPART: lastPART,
+	}, nil
 }
 
 func (rs *RenditionReportSegment) String() string {
-	return "RenditionReportSegment"
+	var s []string
+
+	s = append(s, fmt.Sprintf(`%s="%s"`, URI, rs.URI))
+
+	if rs.LastMSN != 0 {
+		s = append(s, fmt.Sprintf("%s=%d", LASTMSN, rs.LastMSN))
+	}
+
+	if rs.LastPART != 0 {
+		s = append(s, fmt.Sprintf("%s=%d", LASTPART, rs.LastPART))
+	}
+	return fmt.Sprintf("%s:%s", ExtRenditionReport, strings.Join(s, ","))
 }

--- a/report.go
+++ b/report.go
@@ -1,0 +1,15 @@
+package m3u8
+
+type RenditionReportSegment struct {
+	URI      string
+	LastMSN  int
+	LastPART int
+}
+
+func NewReport(line string) (*RenditionReportSegment, error) {
+	return &RenditionReportSegment{}, nil
+}
+
+func (rs *RenditionReportSegment) String() string {
+	return "RenditionReportSegment"
+}

--- a/report_test.go
+++ b/report_test.go
@@ -1,0 +1,7 @@
+package m3u8_test
+
+import "testing"
+
+func TestReport(t *testing.T) {
+
+}

--- a/report_test.go
+++ b/report_test.go
@@ -1,7 +1,22 @@
 package m3u8_test
 
-import "testing"
+import (
+	"testing"
+
+	m3u8 "github.com/poccariswet/m3u8-decoder"
+	"github.com/stretchr/testify/assert"
+)
 
 func TestReport(t *testing.T) {
+	line := `#EXT-X-RENDITION-REPORT:URI="../1M/waitForMSN.php",LAST-MSN=273,LAST-PART=2`
 
+	report, err := m3u8.NewReport(line)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "../1M/waitForMSN.php", report.URI)
+	assert.Equal(t, uint64(273), report.LastMSN)
+	assert.Equal(t, uint64(2), report.LastPART)
+	assert.Equal(t, line, report.String())
 }


### PR DESCRIPTION
# EXT-X-RENDITION-REPORT:<attribute-list>

EXT-X-RENDITION-REPORT carries information about an associated rendition that is as up-to-date as the playlist that contains it. It is added to the playlist in response to a _HLS_report=<path> query parameter.

A server may return more EXT-RENDITION-REPORT tags than requested. The attribute list can consist of the following attributes:

* URI=<uri>: (mandatory) Indicates the Media Playlist described in the report. It should be the same string as the report query parameter.

* LAST-MSN=<N>: (mandatory) Indicates the media sequence number of the last segment currently in the specified rendition.

* LAST-PART=<M>: Indicates the last part of the segment specified by the media sequence number currently in the specified rendition. It is mandatory if the associated playlist contains EXT-X-PART tags.

Currently the prototype tools also generate LAST-I-MSN and LAST-I-PART parameters to indicate the MSN and part of the last independent part. But these may not make it into the specification because they are currently unused.