### PR TITLE
EXT-X-SKIP

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -34,6 +34,7 @@ const (
 	ExtPartInf         = `#EXT-X-PART-INF`
 	ExtPart            = `#EXT-X-PART`
 	ExtRenditionReport = `#EXT-X-RENDITION-REPORT`
+	ExtSkip            = `#EXT-X-SKIP`
 
 	// rendition report
 	LASTMSN  = "LAST-MSN"
@@ -49,6 +50,9 @@ const (
 	PARTTARGET  = "PART-TARGET"
 	INDEPENDENT = "INDEPENDENT"
 	GAP         = "GAP"
+
+	// skip
+	SKIPPEDSEGMENTS = "SKIPPED-SEGMENTS"
 
 	// Utility tag
 	URI      = "URI"

--- a/skip.go
+++ b/skip.go
@@ -1,0 +1,13 @@
+package m3u8
+
+type SkipSegment struct {
+	SkippedSegments uint64
+}
+
+func NewSkip(line string) (*SkipSegment, error) {
+	return &SkipSegment{}, nil
+}
+
+func (ss *SkipSegment) String() string {
+	return "SkipSegment"
+}

--- a/skip.go
+++ b/skip.go
@@ -1,13 +1,27 @@
 package m3u8
 
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
 type SkipSegment struct {
 	SkippedSegments uint64
 }
 
 func NewSkip(line string) (*SkipSegment, error) {
-	return &SkipSegment{}, nil
+	item := parseLine(line[len(ExtSkip+":"):])
+
+	skip, err := extractUint64(item, SKIPPEDSEGMENTS)
+	if err != nil {
+		return nil, errors.Wrap(err, "extractUint64 err")
+	}
+	return &SkipSegment{
+		SkippedSegments: skip,
+	}, nil
 }
 
 func (ss *SkipSegment) String() string {
-	return "SkipSegment"
+	return fmt.Sprintf("%s:%s=%d", ExtSkip, SKIPPEDSEGMENTS, ss.SkippedSegments)
 }

--- a/skip_test.go
+++ b/skip_test.go
@@ -1,7 +1,20 @@
 package m3u8_test
 
-import "testing"
+import (
+	"testing"
+
+	m3u8 "github.com/poccariswet/m3u8-decoder"
+	"github.com/stretchr/testify/assert"
+)
 
 func TestSkip(t *testing.T) {
+	line := `#EXT-X-SKIP:SKIPPED-SEGMENTS=3`
 
+	skip, err := m3u8.NewSkip(line)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, uint64(3), skip.SkippedSegments)
+	assert.Equal(t, line, skip.String())
 }

--- a/skip_test.go
+++ b/skip_test.go
@@ -1,0 +1,7 @@
+package m3u8_test
+
+import "testing"
+
+func TestSkip(t *testing.T) {
+
+}


### PR DESCRIPTION
EXT-X-SKIP:<attribute-list>
When a server issues a Playlist Delta Update, it replaces Media Segments earlier than the Skip Boundary and their associated tags with an EXT-X-SKIP tag.

The EXT-X-SKIP tag replaces segment URI lines and all of the following tags that are applied to those segments: EXTINF, EXT-X-BYTERANGE, EXT-X-DISCONTINUITY, EXT-X-KEY, EXT-X-MAP, EXT-X-PROGRAM-DATE-TIME, EXT-X-GAP, and EXT-X-BITRATE. All other tags must remain in the Playlist Delta Update. The attribute list can consist of the following attributes:

* SKIPPED-SEGMENTS=<N>: (mandatory) Indicates how many Media Segments were replaced by the EXT-X-SKIP tag, along with their associated tags.

If a client receives a playlist containing an EXT-X-SKIP tag and discovers that it does not already have all of the information that was skipped, it must obtain a complete copy of the playlist by reissuing its playlist request without the _HLS_skip=YES parameter.

A playlist containing an EXT-X-SKIP tag must have an EXT-X-VERSION tag with a value of 9 or higher.